### PR TITLE
Fix ignore pattern handling for directory patterns and paths without slashes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -568,7 +568,7 @@ dependencies = [
 
 [[package]]
 name = "pcc"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "clap",
  "clipboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "pcc"
-version = "0.6.3"
+version = "0.6.4"
 edition = "2021"
-description = "A simple command line tool that combines source code files in a project directory into a single file or copy to clipboard."
+description = "A command-line tool that combines project source code files into structured XML output, with support for file targeting, dependency resolution, and clipboard integration."
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/kosaki08/project-code-combiner"

--- a/src/main.rs
+++ b/src/main.rs
@@ -479,6 +479,10 @@ fn is_ignored(file_path: &Path, ignore_patterns: &str) -> bool {
 fn convert_ignore_pattern_to_regex(pattern: &str) -> String {
     let mut regex_pattern = String::new();
 
+    if pattern.ends_with('/') {
+        regex_pattern.push_str(".*");
+    }
+
     let mut in_bracket = false;
     for c in pattern.chars() {
         match c {
@@ -499,7 +503,11 @@ fn convert_ignore_pattern_to_regex(pattern: &str) -> String {
         }
     }
 
-    format!("^{}$", regex_pattern)
+    if !pattern.contains('/') {
+        format!("(?:^|.*/){}$", regex_pattern)
+    } else {
+        format!("^{}$", regex_pattern)
+    }
 }
 
 fn expand_tilde(path: &str) -> PathBuf {


### PR DESCRIPTION
- Enhance ignore pattern conversion to support directory-level matching
- Update regex pattern generation for more flexible file and directory ignoring
- Improve project description to highlight advanced features
- Bump version to 0.6.4